### PR TITLE
Fix the URL for posting follow-ups

### DIFF
--- a/telex/client.py
+++ b/telex/client.py
@@ -26,7 +26,7 @@ class Client(object):
         return self.post_message('user', user_uuid, body, title, action)
 
     def add_followup(self, message_uuid, body):
-        return self._post('/producer/messages/{}'.format(message_uuid), {'body': body})
+        return self._post('/producer/messages/{}/followups'.format(message_uuid), {'body': body})
 
     def post_message(self, target_type, target_id, body, title, action):
         payload = {


### PR DESCRIPTION
The previous URL returns a 404. This one is [pulled from minitel](https://github.com/heroku/minitel/blob/25dd8b9/lib/minitel/client.rb#L38).